### PR TITLE
fix missing brackets in vault CR 

### DIFF
--- a/docs/istio/cr-istio.yaml
+++ b/docs/istio/cr-istio.yaml
@@ -67,7 +67,7 @@ spec:
     # Specify Ingress object annotations here, if TLS is enabled (which is by default)
     # the operator will add NGINX, Traefik and HAProxy Ingress compatible annotations
     # to support TLS backends
-    annotations:
+    annotations: {}
     # Override the default Ingress specification here
     # This follows the same format as the standard Kubernetes Ingress
     # See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#ingressspec-v1beta1-extensions


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR fixes missing brackets in the CR file

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
When applying the CR file provided in this doc page https://banzaicloud.com/docs/bank-vaults/istio/vault-outside-the-mesh/#install-vault-outside-mesh, this error will show up: `The Vault "vault" is invalid: spec.ingress.annotations: Invalid value: "null": spec.ingress.annotations in body must be of type object: "null"`. 

With the PR fix, the above error will not appear. 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
- [X] Related Helm chart(s) updated (if needed)
