### PR TITLE
Point to vault_agent_token_file from template

### DIFF
--- a/docs/mutating-webhook/consul-template-example.yaml
+++ b/docs/mutating-webhook/consul-template-example.yaml
@@ -9,6 +9,7 @@ metadata:
 data:
   config.hcl: |
     vault {
+      vault_agent_token_file = "/vault/.vault-token"
       ssl {
         ca_cert = "/etc/vault/tls/ca.crt"
       }


### PR DESCRIPTION
As detected in banzaicloud/bank-vaults#1635, recent bank-vaults makes consul-template fail as it can no longer find the vault token file.

This change mitigates issue by making example in documentation refer to vault_agent_token_file.

| Q               | A
| --------------- | ---
| Bug fix?        | mitigation
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | partially #banzaicloud/bank-vaults#1635
| License         | Apache 2.0


### What's in this PR?
Makes consul-template template actually work with recent versions of bank-vaults.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

