### PR TITLE
fix: IAM roles fors EKS cluster

### DIFF
--- a/docs/cloud-permissions/_index.md
+++ b/docs/cloud-permissions/_index.md
@@ -89,7 +89,8 @@ cat > vault-policy.json <<EOF
             "Effect": "Allow",
             "Action": [
                 "s3:PutObject",
-                "s3:GetObject"
+                "s3:GetObject",
+                "s3:DeleteObject"
             ],
             "Resource": [
                 "arn:aws:s3:::${BUCKET}/*"
@@ -134,7 +135,7 @@ export VAULT_TOKEN="$(aws kms decrypt \
 The Instance profile in which the Pod is running has to have the following IAM Policies:
 
 - KMS: `kms:Encrypt, kms:Decrypt`
-- S3:  `s3:GetObject, s3:PutObject` on object level and `s3:ListBucket` on bucket level
+- S3:  `s3:GetObject, s3:PutObject`, `s3:DeleteObject` on object level and `s3:ListBucket` on bucket level
 
 An example command how to init and unseal Vault on AWS:
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | NA
| License         | Apache 2.0


### What's in this PR?
The current document doesn't include "s3:DeleteBucket" permission, which is required to revoke leases and it might also be necessary for other delete operations in the vault.

### Why?
Fix AWS Role for vault. s3:DeleteObject is required to revoke leases


### Additional context
NA


### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

### To Do
- [x] If the PR is not complete but you want to discuss the approach, list what remains to be done here
