### PR TITLE
Added mutate-probes webhook annotation

### DIFF
--- a/content/docs/mutating-webhook/annotations.md
+++ b/content/docs/mutating-webhook/annotations.md
@@ -22,6 +22,7 @@ The mutating webhook adds the following PodSpec, Secret, ConfigMap, and CRD anno
 `vault.security.banzaicloud.io/mutate-configmap`|`"false"`|Mutate the annotated ConfigMap as well (only Secrets and Pods are mutated by default)|
 `vault.security.banzaicloud.io/enable-json-log`|`"false"`|Log in JSON format in `vault-env`|
 `vault.security.banzaicloud.io/mutate`|`""`|Defines the mutation of the given resource, possible values: `"skip"` which prevents it.|
+`vault.security.banzaicloud.io/mutate-probes`|`"false"`|Mutate the ENV passed to a liveness or readiness probe.|
 `vault.security.banzaicloud.io/vault-env-from-path`|`""`|Comma-delimited list of vault paths to pull in all secrets as environment variables|
 `vault.security.banzaicloud.io/token-auth-mount`|`""`|`{volume:file}` to be injected as `.vault-token`. |
 `vault.security.banzaicloud.io/vault-auth-method`|`"jwt"`| The [Vault authentication method](https://www.vaultproject.io/docs/auth) to be used, one of `["kubernetes", "aws-ec2", "aws-iam", "gcp-gce", "gcp-iam", "jwt", "azure", "namespaced"]`|

--- a/content/docs/tips-and-tricks/_index.md
+++ b/content/docs/tips-and-tricks/_index.md
@@ -5,20 +5,6 @@ weight: 1150
 
 The following section lists some questions, problems, and tips that came up on the [Bank-Vaults Slack channel](https://pages.banzaicloud.com/invite-slack).
 
-## Mutate ENV passed to a liveness or readiness probe
-
-To mutate the ENV passed to a liveness or readiness probe, just put /vault/vault-env before /bin/sh, for example:
-
-```yaml
-livenessProbe:
-  exec:
-    command:
-    - /vault/vault-env
-    - sh
-    - -c
-    - {{command-to-run}}
-```
-
 ## Login to the Vault web UI
 
 To login to the Vault web UI, you can use the root token, or any configured authentication backend.
@@ -30,3 +16,4 @@ Bank-Vaults never ever deletes the Vault instance from the cluster. However, if 
 ## Set default for vault.security.banzaicloud.io/vault-addr
 
 You can set the default settings for `vault.security.banzaicloud.io/vault-addr` so you don't have to specify it in every PodSpec. Just set the VAULT_ADDR in the env section: [https://github.com/bank-vaults/bank-vaults/blob/3c89e831bdb21b2733680f13ceec7ac4b6e3f892/charts/vault-secrets-webhook/values.yaml#L37](https://github.com/bank-vaults/bank-vaults/blob/3c89e831bdb21b2733680f13ceec7ac4b6e3f892/charts/vault-secrets-webhook/values.yaml#L37)
+


### PR DESCRIPTION
There was an old tip and trick about how to mutate commands in liveness and readiness probes in a pod, but later a new annotation was [introduced](https://github.com/banzaicloud/bank-vaults/pull/1427) for this purpose which is currently missing from the documentation, also making the trick obsolete. 

See the discussion in [this issue](https://github.com/banzaicloud/bank-vaults/issues/1874).