### PR TITLE
Link fixes

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -84,7 +84,7 @@ twitter = "calisti12"
 
   # Uncomment this if your GitHub repo does not have "main" as the default branch,
   # or specify a new value if you want to reference another branch in your GitHub links
-  github_branch= "master"
+  github_branch= "main"
 
 
   # Enable Lunr.js offline search

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: Documentation
 weight: 5
 aliases:
 - /docs/overview/


### PR DESCRIPTION
- Fix top-level breadcrumb
- Point Github links to "main" in the sidebar