### PR TITLE
Point to vault_agent_token_file from template

### DIFF
--- a/content/docs/mutating-webhook/consul-template-example.yaml
+++ b/content/docs/mutating-webhook/consul-template-example.yaml
@@ -9,6 +9,7 @@ metadata:
 data:
   config.hcl: |
     vault {
+      vault_agent_token_file = "/vault/.vault-token"
       ssl {
         ca_cert = "/etc/vault/tls/ca.crt"
       }


### PR DESCRIPTION
As detected in banzaicloud/bank-vaults#1635, recent bank-vaults makes consul-template fail as it can no longer find the vault token file.

This change mitigates issue by making example in documentation refer to vault_agent_token_file.