### PR TITLE
docs: Use verified publisher image `hashicorp/vault`

### DIFF
--- a/content/docs/istio/cr-istio.yaml
+++ b/content/docs/istio/cr-istio.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: vault
 spec:
   size: 1
-  image: hashicorp/vault:1.13.3
+  image: hashicorp/vault:1.14.0
   bankVaultsImage: ghcr.io/bank-vaults/bank-vaults:latest
 
   # Common annotations for all created resources

--- a/content/docs/istio/cr-istio.yaml
+++ b/content/docs/istio/cr-istio.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: vault
 spec:
   size: 1
-  image: vault:1.3.1
+  image: hashicorp/vault:1.13.3
   bankVaultsImage: banzaicloud/bank-vaults:master
 
   # Common annotations for all created resources

--- a/content/docs/mutating-webhook/annotations.md
+++ b/content/docs/mutating-webhook/annotations.md
@@ -8,7 +8,7 @@ The mutating webhook adds the following PodSpec, Secret, ConfigMap, and CRD anno
 |Annotation    |default     |Explanation |
 |--------------|------------|------------|
 `vault.security.banzaicloud.io/vault-addr`|`"https://vault:8200"`|Same as VAULT_ADDR|
-`vault.security.banzaicloud.io/vault-image`|`"vault:latest"`|Vault agent image|
+`vault.security.banzaicloud.io/vault-image`|`"hashicorp/vault:latest"`|Vault agent image|
 `vault.security.banzaicloud.io/vault-image-pull-policy`|`IfNotPresent`|the Pull policy for the vault agent container|
 `vault.security.banzaicloud.io/vault-role`|`""`|The Vault role for Vault agent to use, for Pods it is the name of the ServiceAccount if not specified|
 `vault.security.banzaicloud.io/vault-path`|`"kubernetes"`|The mount path of the auth method|

--- a/content/docs/mutating-webhook/consul-template.md
+++ b/content/docs/mutating-webhook/consul-template.md
@@ -55,7 +55,7 @@ For the webhook to detect that it will need to mutate or change a PodSpec, add t
 
 |Variable      |default     |Explanation|
 |--------------|------------|------------|
-|VAULT_IMAGE   |vault:latest|the vault image to use for the init container|
+|VAULT_IMAGE   |hashicorp/vault:latest|the vault image to use for the init container|
 |VAULT_ENV_IMAGE|banzaicloud/vault-env:latest| the vault-env image to use |
 |VAULT_CT_IMAGE|hashicorp/consul-template:latest| the consul template image to use|
 |VAULT_ADDR    |https://127.0.0.1:8200|Kubernetes service Vault endpoint URL|

--- a/content/docs/mutating-webhook/howto-ct-prom.md
+++ b/content/docs/mutating-webhook/howto-ct-prom.md
@@ -143,7 +143,7 @@ metadata:
   name: "vault"
 spec:
   size: 2
-  image: vault:1.1.2
+  image: hashicorp/vault:1.13.3
 ```
 
 Our Vault config for telemetry:

--- a/content/docs/mutating-webhook/howto-ct-prom.md
+++ b/content/docs/mutating-webhook/howto-ct-prom.md
@@ -143,7 +143,7 @@ metadata:
   name: "vault"
 spec:
   size: 2
-  image: hashicorp/vault:1.13.3
+  image: hashicorp/vault:1.14.0
 ```
 
 Our Vault config for telemetry:

--- a/content/docs/operator/howto-vault-e2e.md
+++ b/content/docs/operator/howto-vault-e2e.md
@@ -88,7 +88,7 @@ metadata:
   namespace: secrets
 spec:
   size: 2
-  image: vault:1.1.2
+  image: hashicorp/vault:1.13.3
   bankVaultsImage: banzaicloud/bank-vaults:0.4.16
 
   # A YAML representation of a final vault config file.

--- a/content/docs/operator/howto-vault-e2e.md
+++ b/content/docs/operator/howto-vault-e2e.md
@@ -88,7 +88,7 @@ metadata:
   namespace: secrets
 spec:
   size: 2
-  image: hashicorp/vault:1.13.3
+  image: hashicorp/vault:1.14.0
   bankVaultsImage: ghcr.io/bank-vaults/bank-vaults:latest
 
   # A YAML representation of a final vault config file.


### PR DESCRIPTION
Hashicorp has deprecated Duplicative Docker Images (see https://developer.hashicorp.com/vault/docs/v1.13.x/deprecation).
New versions of vault are only published to https://hub.docker.com/hashicorp/vault.
https://hub.docker.com/_/vault only contains old versions up to 1.13.3.

Also updated default Vault image version to latest (1.14.0)
