### PR TITLE
docs: Update broken operator links post migration

### DIFF
--- a/content/docs/hsm/nitrokey-opensc.md
+++ b/content/docs/hsm/nitrokey-opensc.md
@@ -177,7 +177,7 @@ Since the HSM is a hardware device connected to a physical node, Bank-Vaults has
     kubectl delete vault vault
     kubectl delete pvc vault-file-vault-0
     kubectl delete secret vault-unseal-keys
-    kubectl apply -f https://raw.githubusercontent.com/banzaicloud/bank-vaults/master/operator/deploy/cr-hsm-nitrokey.yaml
+    kubectl apply -f https://raw.githubusercontent.com/bank-vaults/vault-operator/main/deploy/examples/cr-hsm-nitrokey.yaml
     ```
 
 1. Check the logs that unsealing uses the NitroKey HSM device. Run the following command:

--- a/content/docs/hsm/softhsm.md
+++ b/content/docs/hsm/softhsm.md
@@ -32,5 +32,5 @@ To run the whole SoftHSM based example in Kubernetes, run the following commands
 ```bash
 kubectl create namespace vault-infra
 helm upgrade --install vault-operator banzaicloud-stable/vault-operator --namespace vault-infra
-kubectl apply -f https://raw.githubusercontent.com/banzaicloud/bank-vaults/master/operator/deploy/cr-hsm-softhsm.yaml
+kubectl apply -f https://raw.githubusercontent.com/bank-vaults/vault-operator/main/deploy/examples/cr-hsm-softhsm.yaml
 ```

--- a/content/docs/mutating-webhook/deploy.md
+++ b/content/docs/mutating-webhook/deploy.md
@@ -16,7 +16,7 @@ If you are getting the **x509: certificate signed by unknown authority app=vault
 
 `vault-env` by default replaces itself with the original process of the Pod after reading the secrets from Vault, but with the `vault.security.banzaicloud.io/vault-env-daemon: "true"` annotation this behavior can be changed. So `vault-env` can change to `daemon mode`, so `vault-env` starts the original process as a child process and remains in memory, and renews the lease of the requested Vault token and of the dynamic secrets (if requested any) until their final expiration time.
 
-You can find a full example using MySQL dynamic secrets in the [Bank-Vaults project repository](https://raw.githubusercontent.com/banzaicloud/bank-vaults/master/deploy/test-dynamic-env-vars.yaml):
+You can find a full example using MySQL dynamic secrets in the [Bank-Vaults project's Vault Operator repository](https://raw.githubusercontent.com/bank-vaults/vault-operator/main/test/deploy/test-dynamic-env-vars.yaml):
 
 ```bash
 # Deploy MySQL first as the Vault storage backend and our application will request dynamic secrets for this database as well:

--- a/content/docs/mutating-webhook/monitoring.md
+++ b/content/docs/mutating-webhook/monitoring.md
@@ -31,7 +31,7 @@ To monitor the webhook with Prometheus and Grafana, complete the following steps
 1. Create a Prometheus instance which monitors the components of Bank-Vaults:
 
     ```bash
-    kubectl apply -f https://raw.githubusercontent.com/banzaicloud/bank-vaults/master/hack/prometheus.yaml
+    kubectl apply -f https://raw.githubusercontent.com/bank-vaults/vault-operator/main/test/prometheus.yaml
     ```
 
 1. Create a Grafana instance and expose it:

--- a/content/docs/operator/_index.md
+++ b/content/docs/operator/_index.md
@@ -33,8 +33,8 @@ In a production environment you want to run Vault as a cluster. The following CR
 1. Create a Vault instance using the `cr-raft.yaml` custom resource. This will create a Kubernetes `CustomResource` called `vault` that uses the Raft backend:
 
     ```bash
-    kubectl apply -f https://raw.githubusercontent.com/banzaicloud/bank-vaults/master/operator/deploy/rbac.yaml
-    kubectl apply -f https://raw.githubusercontent.com/banzaicloud/bank-vaults/master/operator/deploy/cr-raft.yaml
+    kubectl apply -f https://raw.githubusercontent.com/bank-vaults/vault-operator/main/test/rbac.yaml
+    kubectl apply -f https://raw.githubusercontent.com/bank-vaults/vault-operator/main/deploy/examples/cr-raft.yaml
     ```
 
 {{< warning >}}

--- a/content/headless/deploy-operator-local.md
+++ b/content/headless/deploy-operator-local.md
@@ -25,11 +25,9 @@ This is the simplest scenario: you install the Vault operator on a simple cluste
 
 1. Create a Vault instance using the Vault custom resources. This will create a Kubernetes `CustomResource` called `vault` and a PersistentVolumeClaim for it:
 
-    > Note: The following commands use a specific version of the CRs, because the current version is not yet working, as we are in the process of migrating the Bank-Vaults repositories.
-
     ```bash
-    kubectl apply -f https://raw.githubusercontent.com/banzaicloud/bank-vaults/v1.15.3/operator/deploy/rbac.yaml
-    kubectl apply -f https://raw.githubusercontent.com/banzaicloud/bank-vaults/v1.15.3/operator/deploy/cr.yaml
+    kubectl apply -f https://raw.githubusercontent.com/bank-vaults/vault-operator/main/test/rbac.yaml
+    kubectl apply -f https://raw.githubusercontent.com/bank-vaults/vault-operator/main/deploy/examples/cr-raft.yaml
     ```
 
 1. Wait a few seconds, then check the operator and the vault pods:
@@ -106,6 +104,6 @@ This is the simplest scenario: you install the Vault operator on a simple cluste
 For other configuration examples of the Vault CustomResource, see the YAML files in the [operator/deploy directory of the project](https://github.com/bank-vaults/bank-vaults/tree/master/operator/deploy) (we use these for testing). After you are done experimenting with Bank-Vaults and you want to delete the operator, you can delete the related CRs:
 
 ```bash
-kubectl delete -f https://raw.githubusercontent.com/banzaicloud/bank-vaults/master/operator/deploy/rbac.yaml
-kubectl delete -f https://raw.githubusercontent.com/banzaicloud/bank-vaults/master/operator/deploy/cr.yaml
+kubectl delete -f https://raw.githubusercontent.com/bank-vaults/vault-operator/main/test/rbac.yaml
+kubectl delete -f https://raw.githubusercontent.com/bank-vaults/vault-operator/main/deploy/examples/cr-raft.yaml
 ```


### PR DESCRIPTION
Update broken `vault-operator` links post migration