### PR TITLE
docs: Prevent tree redirect to blob

### DIFF
--- a/content/docs/go-library/_index.md
+++ b/content/docs/go-library/_index.md
@@ -26,6 +26,6 @@ The [vault-sdk repository](https://github.com/bank-vaults/vault-sdk) contains se
 
 Some examples are in `cmd/examples/main.go` of the [vault-operator](https://github.com/bank-vaults/vault-operator/) repository.
 
-- [Vault client example](https://github.com/bank-vaults/vault-operator/tree/main/cmd/examples/main.go#L28)
-- [Dynamic secrets for MySQL example with Gorm](https://github.com/bank-vaults/vault-operator/tree/main/cmd/examples/main.go#L69)
-- [JWTAuth tokens example with a Gin middleware](https://github.com/bank-vaults/vault-operator/tree/main/cmd/examples/main.go)
+- [Vault client example](https://github.com/bank-vaults/vault-operator/blob/main/cmd/examples/main.go#L28)
+- [Dynamic secrets for MySQL example with Gorm](https://github.com/bank-vaults/vault-operator/blob/main/cmd/examples/main.go#L69)
+- [JWTAuth tokens example with a Gin middleware](https://github.com/bank-vaults/vault-operator/blob/main/cmd/examples/main.go)

--- a/content/docs/mutating-webhook/configuration.md
+++ b/content/docs/mutating-webhook/configuration.md
@@ -145,7 +145,7 @@ In this case, an init-container will be injected into the given Pod. This contai
 Currently, the Kubernetes Service Account-based Vault authentication mechanism is used by `vault-env`, so it requests a Vault token based on the Service Account of the container it is injected into.
 
 - [GCP](https://developer.hashicorp.com/vault/docs/auth/gcp) and general [OIDC/JWT](https://developer.hashicorp.com/vault/docs/auth/jwt) authentication methods are supported as well, see the [example manifest](https://github.com/bank-vaults/vault-operator/blob/main/test/deploy/test-deployment-gcp.yaml).
-- Kubernetes [Projected Service Account Tokens](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) work too, as shown in [this example](https://github.com/bank-vaults/vault-operator/tree/main/test/oidc-pod.yaml).
+- Kubernetes [Projected Service Account Tokens](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) work too, as shown in [this example](https://github.com/bank-vaults/vault-operator/blob/main/test/oidc-pod.yaml).
 
 Kubernetes 1.12 introduced a feature called [APIServer dry-run](https://kubernetes.io/blog/2019/01/14/apiserver-dry-run-and-kubectl-diff/) which became beta as of 1.13. This feature requires some changes in webhooks with side effects. Vault mutating admission webhook is `dry-run aware`.
 

--- a/content/docs/mutating-webhook/external-vault.md
+++ b/content/docs/mutating-webhook/external-vault.md
@@ -37,7 +37,7 @@ Basically, you have to grant `cluster2` access to the Vault running on `cluster1
     kubectl get secret $(kubectl get sa vault -o jsonpath='{.secrets[0].name}') -o jsonpath='{.data.token}' | base64 --decode
     ```
 
-1. In the `vault.banzaicloud.com` custom resource (for example, [https://github.com/bank-vaults/vault-operator/tree/main/deploy/examples/cr.yaml](https://github.com/bank-vaults/vault-operator/tree/main/deploy/examples/cr.yaml)) of `cluster1`, define an `externalConfig` section. Fill the values of the `kubernetes_ca_cert`, `kubernetes_host`, and `token_reviewer_jwt` using the data collected in the previous steps.
+1. In the `vault.banzaicloud.com` custom resource (for example, [https://github.com/bank-vaults/vault-operator/blob/main/deploy/examples/cr.yaml](https://github.com/bank-vaults/vault-operator/blob/main/deploy/examples/cr.yaml)) of `cluster1`, define an `externalConfig` section. Fill the values of the `kubernetes_ca_cert`, `kubernetes_host`, and `token_reviewer_jwt` using the data collected in the previous steps.
 
     ```yaml
       externalConfig:


### PR DESCRIPTION
Prevent GitHub links' `tree` redirecting to `blob`