### PR TITLE
PoC: Generate CRD docs with operator-tools

### DIFF
--- a/content/docs/reference/_index.md
+++ b/content/docs/reference/_index.md
@@ -1,0 +1,12 @@
+---
+title: Available CRDs
+generated_file: true
+weight: 5000
+---
+
+| Name | Description | Version |
+|---|---|---|
+| **[EmbeddedPodSpec](v1alpha1/embedded_v1/)** |  | v1alpha1 |
+| **[VaultSpec](v1alpha1/vault_types/)** |  | v1alpha1 |
+		
+

--- a/content/docs/reference/v1alpha1/_index.md
+++ b/content/docs/reference/v1alpha1/_index.md
@@ -1,0 +1,5 @@
+---
+title: Available CRDs
+generated_file: true
+weight: 5000
+---

--- a/content/docs/reference/v1alpha1/embedded_v1.md
+++ b/content/docs/reference/v1alpha1/embedded_v1.md
@@ -1,0 +1,292 @@
+---
+title: EmbeddedPodSpec
+weight: 200
+generated_file: true
+---
+
+## EmbeddedPodSpec
+
+EmbeddedPodSpec is a description of a pod, which allows containers to be missing, almost as k8s.io/api/core/v1.PodSpec.
+
+### volumes ([]v1.Volume, optional) {#embeddedpodspec-volumes}
+
+List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes +optional +patchMergeKey=name +patchStrategy=merge,retainKeys 
+
+Default: -
+
+### initContainers ([]v1.Container, optional) {#embeddedpodspec-initcontainers}
+
+List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/ +patchMergeKey=name +patchStrategy=merge 
+
+Default: -
+
+### containers ([]v1.Container, optional) {#embeddedpodspec-containers}
+
+List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. +patchMergeKey=name +patchStrategy=merge 
+
+Default: -
+
+### ephemeralContainers ([]v1.EphemeralContainer, optional) {#embeddedpodspec-ephemeralcontainers}
+
+List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. +optional +patchMergeKey=name +patchStrategy=merge 
+
+Default: -
+
+### restartPolicy (v1.RestartPolicy, optional) {#embeddedpodspec-restartpolicy}
+
+Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy +optional 
+
+Default: -
+
+### terminationGracePeriodSeconds (*int64, optional) {#embeddedpodspec-terminationgraceperiodseconds}
+
+Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds. +optional 
+
+Default: -
+
+### activeDeadlineSeconds (*int64, optional) {#embeddedpodspec-activedeadlineseconds}
+
+Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer. +optional 
+
+Default: -
+
+### dnsPolicy (v1.DNSPolicy, optional) {#embeddedpodspec-dnspolicy}
+
+Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'. +optional 
+
+Default: -
+
+### nodeSelector (map[string]string, optional) {#embeddedpodspec-nodeselector}
+
+NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ +optional +mapType=atomic 
+
+Default: -
+
+### serviceAccountName (string, optional) {#embeddedpodspec-serviceaccountname}
+
+ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/ +optional 
+
+Default: -
+
+### serviceAccount (string, optional) {#embeddedpodspec-serviceaccount}
+
+DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead. +k8s:conversion-gen=false +optional 
+
+Default: -
+
+### automountServiceAccountToken (*bool, optional) {#embeddedpodspec-automountserviceaccounttoken}
+
+AutomountServiceAccountToken indicates whether a service account token should be automatically mounted. +optional 
+
+Default: -
+
+### nodeName (string, optional) {#embeddedpodspec-nodename}
+
+NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements. +optional 
+
+Default: -
+
+### hostNetwork (bool, optional) {#embeddedpodspec-hostnetwork}
+
+Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false. +k8s:conversion-gen=false +optional 
+
+Default: -
+
+### hostPID (bool, optional) {#embeddedpodspec-hostpid}
+
+Use the host's pid namespace. Optional: Default to false. +k8s:conversion-gen=false +optional 
+
+Default: -
+
+### hostIPC (bool, optional) {#embeddedpodspec-hostipc}
+
+Use the host's ipc namespace. Optional: Default to false. +k8s:conversion-gen=false +optional 
+
+Default: -
+
+### shareProcessNamespace (*bool, optional) {#embeddedpodspec-shareprocessnamespace}
+
+Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false. +k8s:conversion-gen=false +optional 
+
+Default: -
+
+### securityContext (*v1.PodSecurityContext, optional) {#embeddedpodspec-securitycontext}
+
+SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field. +optional 
+
+Default: -
+
+### imagePullSecrets ([]v1.LocalObjectReference, optional) {#embeddedpodspec-imagepullsecrets}
+
+ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod +optional +patchMergeKey=name +patchStrategy=merge 
+
+Default: -
+
+### hostname (string, optional) {#embeddedpodspec-hostname}
+
+Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value. +optional 
+
+Default: -
+
+### subdomain (string, optional) {#embeddedpodspec-subdomain}
+
+If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>". If not specified, the pod will not have a domainname at all. +optional 
+
+Default: -
+
+### affinity (*v1.Affinity, optional) {#embeddedpodspec-affinity}
+
+If specified, the pod's scheduling constraints +optional 
+
+Default: -
+
+### schedulerName (string, optional) {#embeddedpodspec-schedulername}
+
+If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler. +optional 
+
+Default: -
+
+### tolerations ([]v1.Toleration, optional) {#embeddedpodspec-tolerations}
+
+If specified, the pod's tolerations. +optional 
+
+Default: -
+
+### hostAliases ([]v1.HostAlias, optional) {#embeddedpodspec-hostaliases}
+
+HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods. +optional +patchMergeKey=ip +patchStrategy=merge 
+
+Default: -
+
+### priorityClassName (string, optional) {#embeddedpodspec-priorityclassname}
+
+If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default. +optional 
+
+Default: -
+
+### priority (*int32, optional) {#embeddedpodspec-priority}
+
+The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority. +optional 
+
+Default: -
+
+### dnsConfig (*v1.PodDNSConfig, optional) {#embeddedpodspec-dnsconfig}
+
+Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy. +optional 
+
+Default: -
+
+### readinessGates ([]v1.PodReadinessGate, optional) {#embeddedpodspec-readinessgates}
+
+If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates +optional 
+
+Default: -
+
+### runtimeClassName (*string, optional) {#embeddedpodspec-runtimeclassname}
+
+RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class +optional 
+
+Default: -
+
+### enableServiceLinks (*bool, optional) {#embeddedpodspec-enableservicelinks}
+
+EnableServiceLinks indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Defaults to true. +optional 
+
+Default: -
+
+### preemptionPolicy (*v1.PreemptionPolicy, optional) {#embeddedpodspec-preemptionpolicy}
+
+PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. +optional 
+
+Default: -
+
+### overhead (v1.ResourceList, optional) {#embeddedpodspec-overhead}
+
+Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md +optional 
+
+Default: -
+
+### topologySpreadConstraints ([]v1.TopologySpreadConstraint, optional) {#embeddedpodspec-topologyspreadconstraints}
+
+TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed. +optional +patchMergeKey=topologyKey +patchStrategy=merge +listType=map +listMapKey=topologyKey +listMapKey=whenUnsatisfiable 
+
+Default: -
+
+### setHostnameAsFQDN (*bool, optional) {#embeddedpodspec-sethostnameasfqdn}
+
+If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default). In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname). In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN. If a pod does not have FQDN, this has no effect. Default to false. +optional 
+
+Default: -
+
+### os (*v1.PodOS, optional) {#embeddedpodspec-os}
+
+Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.  If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions  If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup +optional 
+
+Default: -
+
+### hostUsers (*bool, optional) {#embeddedpodspec-hostusers}
+
+Use the host's user namespace. Optional: Default to true. If set to true or not present, the pod will be run in the host user namespace, useful for when the pod needs a feature only available to the host user namespace, such as loading a kernel module with CAP_SYS_MODULE. When set to false, a new userns is created for the pod. Setting false is useful for mitigating container breakout vulnerabilities even allowing users to run their containers as root without actually having root privileges on the host. This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature. +k8s:conversion-gen=false +optional 
+
+Default: -
+
+### schedulingGates ([]v1.PodSchedulingGate, optional) {#embeddedpodspec-schedulinggates}
+
+SchedulingGates is an opaque list of values that if specified will block scheduling the pod. More info:  https://git.k8s.io/enhancements/keps/sig-scheduling/3521-pod-scheduling-readiness.  This is an alpha-level feature enabled by PodSchedulingReadiness feature gate. +optional +patchMergeKey=name +patchStrategy=merge +listType=map +listMapKey=name 
+
+Default: -
+
+### resourceClaims ([]v1.PodResourceClaim, optional) {#embeddedpodspec-resourceclaims}
+
+ResourceClaims defines which ResourceClaims must be allocated and reserved before the Pod is allowed to start. The resources will be made available to those containers which consume them by name.  This is an alpha field and requires enabling the DynamicResourceAllocation feature gate.  This field is immutable.  +patchMergeKey=name +patchStrategy=merge,retainKeys +listType=map +listMapKey=name +featureGate=DynamicResourceAllocation +optional 
+
+Default: -
+
+
+## EmbeddedPersistentVolumeClaim
+
+EmbeddedPersistentVolumeClaim is an embeddable and controller-gen friendly version of k8s.io/api/core/v1.PersistentVolumeClaim.
+It contains TypeMeta and a reduced ObjectMeta.
+
+###  (metav1.TypeMeta, required) {#embeddedpersistentvolumeclaim-}
+
+Default: -
+
+### metadata (EmbeddedObjectMetadata, optional) {#embeddedpersistentvolumeclaim-metadata}
+
+EmbeddedObjectMetadata contains metadata relevant to an EmbeddedResource. 
+
+Default: -
+
+### spec (v1.PersistentVolumeClaimSpec, optional) {#embeddedpersistentvolumeclaim-spec}
+
+Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims +optional 
+
+Default: -
+
+
+## EmbeddedObjectMetadata
+
+EmbeddedObjectMetadata contains a subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta
+Only fields which are relevant to embedded resources are included.
+controller-gen discards embedded ObjectMetadata type fields, so we have to overcome this.
+
+### name (string, optional) {#embeddedobjectmetadata-name}
+
+Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names +optional 
+
+Default: -
+
+### labels (map[string]string, optional) {#embeddedobjectmetadata-labels}
+
+Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels +optional 
+
+Default: -
+
+### annotations (map[string]string, optional) {#embeddedobjectmetadata-annotations}
+
+Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations +optional 
+
+Default: -
+
+

--- a/content/docs/reference/v1alpha1/vault_types.md
+++ b/content/docs/reference/v1alpha1/vault_types.md
@@ -1,0 +1,682 @@
+---
+title: VaultSpec
+weight: 200
+generated_file: true
+---
+
+## VaultSpec
+
+VaultSpec defines the desired state of Vault
+
+### size (int32, optional) {#vaultspec-size}
+
+Size defines the number of Vault instances in the cluster (>= 1 means HA) default: 1 
+
+Default: -
+
+### image (string, optional) {#vaultspec-image}
+
+Image specifies the Vault image to use for the Vault instances default: hashicorp/vault:latest 
+
+Default: -
+
+### bankVaultsImage (string, optional) {#vaultspec-bankvaultsimage}
+
+BankVaultsImage specifies the Bank Vaults image to use for Vault unsealing and configuration default: ghcr.io/bank-vaults/bank-vaults:latest 
+
+Default: -
+
+### bankVaultsVolumeMounts ([]v1.VolumeMount, optional) {#vaultspec-bankvaultsvolumemounts}
+
+BankVaultsVolumeMounts define some extra Kubernetes Volume mounts for the Bank Vaults Sidecar container. default: 
+
+Default: -
+
+### statsdDisabled (bool, optional) {#vaultspec-statsddisabled}
+
+StatsDDisabled specifies if StatsD based metrics should be disabled default: false 
+
+Default: -
+
+### statsdImage (string, optional) {#vaultspec-statsdimage}
+
+StatsDImage specifices the StatsD image to use for Vault metrics exportation default: prom/statsd-exporter:latest 
+
+Default: -
+
+### statsdConfig (string, optional) {#vaultspec-statsdconfig}
+
+StatsdConfig specifices the StatsD mapping configuration default: 
+
+Default: -
+
+### fluentdEnabled (bool, optional) {#vaultspec-fluentdenabled}
+
+FluentDEnabled specifies if FluentD based log exportation should be enabled default: false 
+
+Default: -
+
+### fluentdImage (string, optional) {#vaultspec-fluentdimage}
+
+FluentDImage specifices the FluentD image to use for Vault log exportation default: fluent/fluentd:edge 
+
+Default: -
+
+### fluentdConfLocation (string, optional) {#vaultspec-fluentdconflocation}
+
+FluentDConfLocation is the location of the fluent.conf file default: "/fluentd/etc" 
+
+Default: -
+
+### fluentdConfFile (string, optional) {#vaultspec-fluentdconffile}
+
+FluentDConfFile specifices the FluentD configuration file name to use for Vault log exportation default: 
+
+Default: -
+
+### fluentdConfig (string, optional) {#vaultspec-fluentdconfig}
+
+FluentDConfig specifices the FluentD configuration to use for Vault log exportation default: 
+
+Default: -
+
+### watchedSecretsLabels ([]map[string]string, optional) {#vaultspec-watchedsecretslabels}
+
+WatchedSecretsLabels specifices a set of Kubernetes label selectors which select Secrets to watch. If these Secrets change the Vault cluster gets restarted. For example a Secret that Cert-Manager is managing a public Certificate for Vault using let's Encrypt. default: 
+
+Default: -
+
+### watchedSecretsAnnotations ([]map[string]string, optional) {#vaultspec-watchedsecretsannotations}
+
+WatchedSecretsAnnotations specifices a set of Kubernetes annotations selectors which select Secrets to watch. If these Secrets change the Vault cluster gets restarted. For example a Secret that Cert-Manager is managing a public Certificate for Vault using let's Encrypt. default: 
+
+Default: -
+
+### annotations (map[string]string, optional) {#vaultspec-annotations}
+
+Annotations define a set of common Kubernetes annotations that will be added to all operator managed resources. default: 
+
+Default: -
+
+### vaultAnnotations (map[string]string, optional) {#vaultspec-vaultannotations}
+
+VaultAnnotations define a set of Kubernetes annotations that will be added to all Vault Pods. default: 
+
+Default: -
+
+### vaultLabels (map[string]string, optional) {#vaultspec-vaultlabels}
+
+VaultLabels define a set of Kubernetes labels that will be added to all Vault Pods. default: 
+
+Default: -
+
+### vaultPodSpec (*EmbeddedPodSpec, optional) {#vaultspec-vaultpodspec}
+
+VaultPodSpec is a Kubernetes Pod specification snippet (`spec:` block) that will be merged into the operator generated Vault Pod specification. default: 
+
+Default: -
+
+### vaultContainerSpec (v1.Container, optional) {#vaultspec-vaultcontainerspec}
+
+VaultContainerSpec is a Kubernetes Container specification snippet that will be merged into the operator generated Vault Container specification. default: 
+
+Default: -
+
+### vaultConfigurerAnnotations (map[string]string, optional) {#vaultspec-vaultconfigurerannotations}
+
+VaultConfigurerAnnotations define a set of Kubernetes annotations that will be added to the Vault Configurer Pod. default: 
+
+Default: -
+
+### vaultConfigurerLabels (map[string]string, optional) {#vaultspec-vaultconfigurerlabels}
+
+VaultConfigurerLabels define a set of Kubernetes labels that will be added to all Vault Configurer Pod. default: 
+
+Default: -
+
+### vaultConfigurerPodSpec (*EmbeddedPodSpec, optional) {#vaultspec-vaultconfigurerpodspec}
+
+VaultConfigurerPodSpec is a Kubernetes Pod specification snippet (`spec:` block) that will be merged into the operator generated Vault Configurer Pod specification. default: 
+
+Default: -
+
+### config (extv1beta1.JSON, required) {#vaultspec-config}
+
+Config is the Vault Server configuration. See https://www.vaultproject.io/docs/configuration/ for more details. default: 
+
+Default: -
+
+### externalConfig (extv1beta1.JSON, optional) {#vaultspec-externalconfig}
+
+ExternalConfig is higher level configuration block which instructs the Bank Vaults Configurer to configure Vault through its API, thus allows setting up: - Secret Engines - Auth Methods - Audit Devices - Plugin Backends - Policies - Startup Secrets (Bank Vaults feature) A documented example: https://github.com/bank-vaults/vault-operator/blob/main/vault-config.yml default: 
+
+Default: -
+
+### unsealConfig (UnsealConfig, optional) {#vaultspec-unsealconfig}
+
+UnsealConfig defines where the Vault cluster's unseal keys and root token should be stored after initialization. See the type's documentation for more details. Only one method may be specified. default: Kubernetes Secret based unsealing 
+
+Default: -
+
+### credentialsConfig (CredentialsConfig, optional) {#vaultspec-credentialsconfig}
+
+CredentialsConfig defines a external Secret for Vault and how it should be mounted to the Vault Pod for example accessing Cloud resources. default: 
+
+Default: -
+
+### envsConfig ([]v1.EnvVar, optional) {#vaultspec-envsconfig}
+
+EnvsConfig is a list of Kubernetes environment variable definitions that will be passed to all Bank-Vaults pods. default: 
+
+Default: -
+
+### securityContext (v1.PodSecurityContext, optional) {#vaultspec-securitycontext}
+
+SecurityContext is a Kubernetes PodSecurityContext that will be applied to all Pods created by the operator. default: 
+
+Default: -
+
+### serviceType (string, optional) {#vaultspec-servicetype}
+
+ServiceType is a Kubernetes Service type of the Vault Service. default: ClusterIP 
+
+Default: -
+
+### loadBalancerIP (string, optional) {#vaultspec-loadbalancerip}
+
+LoadBalancerIP is an optional setting for allocating a specific address for the entry service object of type LoadBalancer default: "" 
+
+Default: -
+
+### serviceRegistrationEnabled (bool, optional) {#vaultspec-serviceregistrationenabled}
+
+serviceRegistrationEnabled enables the injection of the service_registration Vault stanza. This requires elaborated RBAC privileges for updating Pod labels for the Vault Pod. default: false 
+
+Default: -
+
+### raftLeaderAddress (string, optional) {#vaultspec-raftleaderaddress}
+
+RaftLeaderAddress defines the leader address of the raft cluster in multi-cluster deployments. (In single cluster (namespace) deployments it is automatically detected). "self" is a special value which means that this instance should be the bootstrap leader instance. default: "" 
+
+Default: -
+
+### servicePorts (map[string]int32, optional) {#vaultspec-serviceports}
+
+ServicePorts is an extra map of ports that should be exposed by the Vault Service. default: 
+
+Default: -
+
+### affinity (*v1.Affinity, optional) {#vaultspec-affinity}
+
+Affinity is a group of affinity scheduling rules applied to all Vault Pods. default: 
+
+Default: -
+
+### podAntiAffinity (string, optional) {#vaultspec-podantiaffinity}
+
+PodAntiAffinity is the TopologyKey in the Vault Pod's PodAntiAffinity. No PodAntiAffinity is used if empty. Deprecated. Use Affinity. default: 
+
+Default: -
+
+### nodeAffinity (v1.NodeAffinity, optional) {#vaultspec-nodeaffinity}
+
+NodeAffinity is Kubernetees NodeAffinity definition that should be applied to all Vault Pods. Deprecated. Use Affinity. default: 
+
+Default: -
+
+### nodeSelector (map[string]string, optional) {#vaultspec-nodeselector}
+
+NodeSelector is Kubernetees NodeSelector definition that should be applied to all Vault Pods. default: 
+
+Default: -
+
+### tolerations ([]v1.Toleration, optional) {#vaultspec-tolerations}
+
+Tolerations is Kubernetes Tolerations definition that should be applied to all Vault Pods. default: 
+
+Default: -
+
+### serviceAccount (string, optional) {#vaultspec-serviceaccount}
+
+ServiceAccount is Kubernetes ServiceAccount in which the Vault Pods should be running in. default: default 
+
+Default: -
+
+### volumes ([]v1.Volume, optional) {#vaultspec-volumes}
+
+Volumes define some extra Kubernetes Volumes for the Vault Pods. default: 
+
+Default: -
+
+### volumeMounts ([]v1.VolumeMount, optional) {#vaultspec-volumemounts}
+
+VolumeMounts define some extra Kubernetes Volume mounts for the Vault Pods. default: 
+
+Default: -
+
+### volumeClaimTemplates ([]EmbeddedPersistentVolumeClaim, optional) {#vaultspec-volumeclaimtemplates}
+
+VolumeClaimTemplates define some extra Kubernetes PersistentVolumeClaim templates for the Vault Statefulset. default: 
+
+Default: -
+
+### vaultEnvsConfig ([]v1.EnvVar, optional) {#vaultspec-vaultenvsconfig}
+
+VaultEnvsConfig is a list of Kubernetes environment variable definitions that will be passed to the Vault container. default: 
+
+Default: -
+
+### sidecarEnvsConfig ([]v1.EnvVar, optional) {#vaultspec-sidecarenvsconfig}
+
+SidecarEnvsConfig is a list of Kubernetes environment variable definitions that will be passed to Vault sidecar containers. default: 
+
+Default: -
+
+### resources (*Resources, optional) {#vaultspec-resources}
+
+Resources defines the resource limits for all the resources created by the operator. See the type for more details. default: 
+
+Default: -
+
+### ingress (*Ingress, optional) {#vaultspec-ingress}
+
+Ingress, if it is specified the operator will create an Ingress resource for the Vault Service and will annotate it with the correct Ingress annotations specific to the TLS settings in the configuration. See the type for more details. default: 
+
+Default: -
+
+### serviceMonitorEnabled (bool, optional) {#vaultspec-servicemonitorenabled}
+
+ServiceMonitorEnabled enables the creation of Prometheus Operator specific ServiceMonitor for Vault. default: false 
+
+Default: -
+
+### existingTlsSecretName (string, optional) {#vaultspec-existingtlssecretname}
+
+ExistingTLSSecretName is name of the secret that contains a TLS server certificate and key and the corresponding CA certificate. Required secret format kubernetes.io/tls type secret keys + ca.crt key If it is set, generating certificate will be disabled default: "" 
+
+Default: -
+
+### tlsExpiryThreshold (string, optional) {#vaultspec-tlsexpirythreshold}
+
+TLSExpiryThreshold is the Vault TLS certificate expiration threshold in Go's Duration format. default: 168h 
+
+Default: -
+
+### tlsAdditionalHosts ([]string, optional) {#vaultspec-tlsadditionalhosts}
+
+TLSAdditionalHosts is a list of additional hostnames or IP addresses to add to the SAN on the automatically generated TLS certificate. default: 
+
+Default: -
+
+### caNamespaces ([]string, optional) {#vaultspec-canamespaces}
+
+CANamespaces define a list of namespaces where the generated CA certificate for Vault should be distributed, use ["*"] for all namespaces. default: 
+
+Default: -
+
+### istioEnabled (bool, optional) {#vaultspec-istioenabled}
+
+IstioEnabled describes if the cluster has a Istio running and enabled. default: false 
+
+Default: -
+
+### veleroEnabled (bool, optional) {#vaultspec-veleroenabled}
+
+VeleroEnabled describes if the cluster has a Velero running and enabled. default: false 
+
+Default: -
+
+### veleroFsfreezeImage (string, optional) {#vaultspec-velerofsfreezeimage}
+
+VeleroFsfreezeImage specifices the Velero Fsrfeeze image to use in Velero backup hooks default: velero/fsfreeze-pause:latest 
+
+Default: -
+
+### vaultContainers ([]v1.Container, optional) {#vaultspec-vaultcontainers}
+
+VaultContainers add extra containers 
+
+Default: -
+
+### vaultInitContainers ([]v1.Container, optional) {#vaultspec-vaultinitcontainers}
+
+VaultInitContainers add extra initContainers 
+
+Default: -
+
+
+## VaultStatus
+
+VaultStatus defines the observed state of Vault
+
+### nodes ([]string, required) {#vaultstatus-nodes}
+
+Important: Run "make generate-code" to regenerate code after modifying this file 
+
+Default: -
+
+### leader (string, required) {#vaultstatus-leader}
+
+Default: -
+
+### conditions ([]v1.ComponentCondition, optional) {#vaultstatus-conditions}
+
+Default: -
+
+
+## UnsealOptions
+
+UnsealOptions represents the common options to all unsealing backends
+
+### preFlightChecks (*bool, optional) {#unsealoptions-preflightchecks}
+
+Default: -
+
+### storeRootToken (*bool, optional) {#unsealoptions-storeroottoken}
+
+Default: -
+
+### secretThreshold (*uint, optional) {#unsealoptions-secretthreshold}
+
+Default: -
+
+### secretShares (*uint, optional) {#unsealoptions-secretshares}
+
+Default: -
+
+
+## UnsealConfig
+
+UnsealConfig represents the UnsealConfig field of a VaultSpec Kubernetes object
+
+### options (UnsealOptions, optional) {#unsealconfig-options}
+
+Default: -
+
+### kubernetes (KubernetesUnsealConfig, optional) {#unsealconfig-kubernetes}
+
+Default: -
+
+### google (*GoogleUnsealConfig, optional) {#unsealconfig-google}
+
+Default: -
+
+### alibaba (*AlibabaUnsealConfig, optional) {#unsealconfig-alibaba}
+
+Default: -
+
+### azure (*AzureUnsealConfig, optional) {#unsealconfig-azure}
+
+Default: -
+
+### aws (*AWSUnsealConfig, optional) {#unsealconfig-aws}
+
+Default: -
+
+### vault (*VaultUnsealConfig, optional) {#unsealconfig-vault}
+
+Default: -
+
+### hsm (*HSMUnsealConfig, optional) {#unsealconfig-hsm}
+
+Default: -
+
+
+## KubernetesUnsealConfig
+
+KubernetesUnsealConfig holds the parameters for Kubernetes based unsealing
+
+### secretNamespace (string, optional) {#kubernetesunsealconfig-secretnamespace}
+
+Default: -
+
+### secretName (string, optional) {#kubernetesunsealconfig-secretname}
+
+Default: -
+
+
+## GoogleUnsealConfig
+
+GoogleUnsealConfig holds the parameters for Google KMS based unsealing
+
+### kmsKeyRing (string, required) {#googleunsealconfig-kmskeyring}
+
+Default: -
+
+### kmsCryptoKey (string, required) {#googleunsealconfig-kmscryptokey}
+
+Default: -
+
+### kmsLocation (string, required) {#googleunsealconfig-kmslocation}
+
+Default: -
+
+### kmsProject (string, required) {#googleunsealconfig-kmsproject}
+
+Default: -
+
+### storageBucket (string, required) {#googleunsealconfig-storagebucket}
+
+Default: -
+
+
+## AlibabaUnsealConfig
+
+AlibabaUnsealConfig holds the parameters for Alibaba Cloud KMS based unsealing
+
+--alibaba-kms-region eu-central-1 --alibaba-kms-key-id 9d8063eb-f9dc-421b-be80-15d195c9f148 --alibaba-oss-endpoint oss-eu-central-1.aliyuncs.com --alibaba-oss-bucket bank-vaults
+
+### kmsRegion (string, required) {#alibabaunsealconfig-kmsregion}
+
+Default: -
+
+### kmsKeyId (string, required) {#alibabaunsealconfig-kmskeyid}
+
+Default: -
+
+### ossEndpoint (string, required) {#alibabaunsealconfig-ossendpoint}
+
+Default: -
+
+### ossBucket (string, required) {#alibabaunsealconfig-ossbucket}
+
+Default: -
+
+### ossPrefix (string, required) {#alibabaunsealconfig-ossprefix}
+
+Default: -
+
+
+## AzureUnsealConfig
+
+AzureUnsealConfig holds the parameters for Azure Key Vault based unsealing
+
+### keyVaultName (string, required) {#azureunsealconfig-keyvaultname}
+
+Default: -
+
+
+## AWSUnsealConfig
+
+AWSUnsealConfig holds the parameters for AWS KMS based unsealing
+
+### kmsKeyId (string, required) {#awsunsealconfig-kmskeyid}
+
+Default: -
+
+### kmsRegion (string, optional) {#awsunsealconfig-kmsregion}
+
+Default: -
+
+### kmsEncryptionContext (string, optional) {#awsunsealconfig-kmsencryptioncontext}
+
+Default: -
+
+### s3Bucket (string, required) {#awsunsealconfig-s3bucket}
+
+Default: -
+
+### s3Prefix (string, required) {#awsunsealconfig-s3prefix}
+
+Default: -
+
+### s3Region (string, optional) {#awsunsealconfig-s3region}
+
+Default: -
+
+### s3SSE (string, optional) {#awsunsealconfig-s3sse}
+
+Default: -
+
+
+## VaultUnsealConfig
+
+VaultUnsealConfig holds the parameters for remote Vault based unsealing
+
+### address (string, required) {#vaultunsealconfig-address}
+
+Default: -
+
+### unsealKeysPath (string, required) {#vaultunsealconfig-unsealkeyspath}
+
+Default: -
+
+### role (string, optional) {#vaultunsealconfig-role}
+
+Default: -
+
+### authPath (string, optional) {#vaultunsealconfig-authpath}
+
+Default: -
+
+### tokenPath (string, optional) {#vaultunsealconfig-tokenpath}
+
+Default: -
+
+### token (string, optional) {#vaultunsealconfig-token}
+
+Default: -
+
+
+## HSMUnsealConfig
+
+HSMUnsealConfig holds the parameters for remote HSM based unsealing
+
+### daemon (bool, optional) {#hsmunsealconfig-daemon}
+
+Default: -
+
+### modulePath (string, required) {#hsmunsealconfig-modulepath}
+
+Default: -
+
+### slotId (uint, optional) {#hsmunsealconfig-slotid}
+
+Default: -
+
+### tokenLabel (string, optional) {#hsmunsealconfig-tokenlabel}
+
+Default: -
+
+### pin (string, required) {#hsmunsealconfig-pin}
+
+Default: -
+
+### keyLabel (string, required) {#hsmunsealconfig-keylabel}
+
+Default: -
+
+
+## CredentialsConfig
+
+CredentialsConfig configuration for a credentials file provided as a secret
+
+### env (string, required) {#credentialsconfig-env}
+
+Default: -
+
+### path (string, required) {#credentialsconfig-path}
+
+Default: -
+
+### secretName (string, required) {#credentialsconfig-secretname}
+
+Default: -
+
+
+## Resources
+
+Resources holds different container's ResourceRequirements
+
+### vault (*v1.ResourceRequirements, optional) {#resources-vault}
+
+Default: -
+
+### bankVaults (*v1.ResourceRequirements, optional) {#resources-bankvaults}
+
+Default: -
+
+### hsmDaemon (*v1.ResourceRequirements, optional) {#resources-hsmdaemon}
+
+Default: -
+
+### prometheusExporter (*v1.ResourceRequirements, optional) {#resources-prometheusexporter}
+
+Default: -
+
+### fluentd (*v1.ResourceRequirements, optional) {#resources-fluentd}
+
+Default: -
+
+
+## Ingress
+
+Ingress specification for the Vault cluster
+
+### annotations (map[string]string, optional) {#ingress-annotations}
+
+Default: -
+
+### spec (netv1.IngressSpec, optional) {#ingress-spec}
+
+Default: -
+
+
+## Vault
+
+Vault is the Schema for the vaults API
+
+###  (metav1.TypeMeta, required) {#vault-}
+
+Default: -
+
+### metadata (metav1.ObjectMeta, optional) {#vault-metadata}
+
+Default: -
+
+### spec (VaultSpec, optional) {#vault-spec}
+
+Default: -
+
+### status (VaultStatus, optional) {#vault-status}
+
+Default: -
+
+
+## VaultList
+
+VaultList contains a list of Vault
+
+###  (metav1.TypeMeta, required) {#vaultlist-}
+
+Default: -
+
+### metadata (metav1.ListMeta, optional) {#vaultlist-metadata}
+
+Default: -
+
+### items ([]Vault, required) {#vaultlist-items}
+
+Default: -
+
+


### PR DESCRIPTION
- Works mostly out-of-the box, just needs some go scripting
- Includes only parameters defined in our go files, it doesn't include the ones we reference and override